### PR TITLE
Add note on keyId in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ E.g. `bootstrap.yml`:
         kms:
             keyId: arn:aws:kms:eu-west-1:089972051332:key/9d9fca31-54c5-4df5-ba4f-127dfb9a5031
 
+The *aws.kms.keyId* property is required only if you intend to encrypt values in your application. The following contains the properties used by this library.
+
+- aws.region (required)
+- aws.kms.keyId
+- aws.kms.enabled (defaults to true)
+
 Usage
 -----
 


### PR DESCRIPTION
As a developer with no management rights to AWS IAM, I couldn't figure out whether I had to enter the keyId or not, so delayed some releases/commits until we had the keyID in the properties.

Turns out that we were using [AWS KMS key policies](http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html), and since the code was only decrypting, we didn't have to specify the keyId at all.

This pull request adds a sentence detailing that, and also the list of available/used properties. Maybe that could go under another section, so just let me know if the text needs to be updated, or moved elsewhere. Happy to update this pull request with further commits.