### PR TITLE
Add support to encryption context

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,26 @@ E.g. `application.yml`
 
     secretPassword: '{cipher}CiA47hYvQqWFFGq3TLtzQO5FwZMam2AnaeQt4PGEZHhDLxFTAQEBAgB4OO4WL0KlhRRqt0y7c0DuRcGTGptgJ8nkLeDxhGR4Qy8AAABqMGgGCSqGSIb3DQEHBqBbMFkCAQAwVAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAx61LJpXQwgTcnGeSQCARCAJ4xhpGC5HT2xT+Vhy2iAuT+P/PLliZK5u6CiGhgudteZsCr7VJ/1aw=='
 
+### Use an encryption context
+
+An [encryption context](http://docs.aws.amazon.com/kms/latest/developerguide/encryption-context.html)
+is a set of key-value pairs used for encrypt and decrypt values, which might be useful as security
+enhancement.
+
+To use an encryption context with this library, you will have to use a custom syntax, that is not part
+of Spring Security (as the {cipher} prefix).
+
+E.g. `application.yml`
+
+    secretPassword: '{cipher}(Country=UG9ydHVnYWw=,Code=MzUx)CiA47hYvQqWFFGq3TLtzQO5FwZMam2AnaeQt4PGEZHhDLxFTAQEBAgB4OO4WL0KlhRRqt0y7c0DuRcGTGptgJ8nkLeDxhGR4Qy8AAABqMGgGCSqGSIb3DQEHBqBbMFkCAQAwVAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAx61LJpXQwgTcnGeSQCARCAJ4xhpGC5HT2xT+Vhy2iAuT+P/PLliZK5u6CiGhgudteZsCr7VJ/1aw=='
+
+The `(Country=UG9ydHVnYWw=,Code=MzUx)` part is the encryption context, where we used two keys for
+this example: Country and Code. And the values are Base64 encoded.
+
+Key-value pairs must be comma separated, and it is fine to use spaces to separate values. The order of the
+values in the context is not important. And one last note, is that the values used in the encryption
+context are logged in CloudTrail, so they must not be sensitive.
+
 Hints
 -----
 

--- a/src/main/java/de/zalando/spring/cloud/config/aws/kms/KmsTextEncryptor.java
+++ b/src/main/java/de/zalando/spring/cloud/config/aws/kms/KmsTextEncryptor.java
@@ -116,11 +116,11 @@ public class KmsTextEncryptor implements TextEncryptor {
             final String[] pairs = encryptionContextText.split(",");
             for (String pair : pairs) {
                 // we must not use simply split("="), as = is a pad symbol in base64, and would be cut out...
-                String[] keyValue = pair.split("=", 1);
+                String[] keyValue = pair.split("=", 2);
                 if (keyValue.length == 1) {
                     encryptionContext.put(keyValue[0], "");
                 } else if (keyValue.length == 2) {
-                    encryptionContext.put(keyValue[0], new String(Base64.decode(keyValue[1].getBytes())));
+                    encryptionContext.put(keyValue[0], new String(Base64.decode(keyValue[1].trim().getBytes())));
                 }
             }
             return encryptionContext;

--- a/src/test/java/de/zalando/spring/cloud/config/aws/kms/KmsEncryptionContextTest.java
+++ b/src/test/java/de/zalando/spring/cloud/config/aws/kms/KmsEncryptionContextTest.java
@@ -28,21 +28,27 @@ import org.junit.Test;
 public class KmsEncryptionContextTest {
 
     private static final String ENCRYPTION_TEXT = "(param=TOKAmWhvbW1lIGPigJllc3Qgcmllbg==,"
-            + "test=bOKAmW9ldXZyZSBj4oCZZXN0IHRvdXQ=,valueless)remaining";
+            + "test=bOKAmW9ldXZyZSBj4oCZZXN0IHRvdXQ= ,valueless)remaining";
+    private static final int NUMBER_OF_ENTRIES = 3;
 
     @Test
     public void testExtractEncryptionContext() {
         Map<String, String> encryptionContext = KmsTextEncryptor.extractEncryptionContext(ENCRYPTION_TEXT);
-        assertEquals(3, encryptionContext.size());
+        assertEquals(NUMBER_OF_ENTRIES, encryptionContext.size());
+        int found = 0;
         for (Entry<String, String> entry : encryptionContext.entrySet()) {
             if ("param".equals(entry.getKey())) {
                 assertEquals("L’homme c’est rien", entry.getValue());
+                found++;
             } else if ("test".equals(entry.getKey())) {
                 assertEquals("l’oeuvre c’est tout", entry.getValue());
+                found++;
             } else if ("valueless".equals(entry.getKey())) {
-                assertEquals("", entry.getValue());
+                assertEquals("An empty value must still be added!", "", entry.getValue());
+                found++;
             }
         }
+        assertEquals("Test did not find right number of key and value pairs", NUMBER_OF_ENTRIES, found);
     }
 
     @Test
@@ -50,5 +56,4 @@ public class KmsEncryptionContextTest {
         String encryptionValue = KmsTextEncryptor.extractEncryptedValue(ENCRYPTION_TEXT);
         assertEquals("remaining", encryptionValue);
     }
-
 }

--- a/src/test/java/de/zalando/spring/cloud/config/aws/kms/KmsEncryptionContextTest.java
+++ b/src/test/java/de/zalando/spring/cloud/config/aws/kms/KmsEncryptionContextTest.java
@@ -15,10 +15,9 @@
  */
 package de.zalando.spring.cloud.config.aws.kms;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.junit.Assert.assertEquals;
-
-import java.util.Map;
-import java.util.Map.Entry;
 
 import org.junit.Test;
 
@@ -29,26 +28,14 @@ public class KmsEncryptionContextTest {
 
     private static final String ENCRYPTION_TEXT = "(param=TOKAmWhvbW1lIGPigJllc3Qgcmllbg==,"
             + "test=bOKAmW9ldXZyZSBj4oCZZXN0IHRvdXQ= ,valueless)remaining";
-    private static final int NUMBER_OF_ENTRIES = 3;
 
     @Test
     public void testExtractEncryptionContext() {
-        Map<String, String> encryptionContext = KmsTextEncryptor.extractEncryptionContext(ENCRYPTION_TEXT);
-        assertEquals(NUMBER_OF_ENTRIES, encryptionContext.size());
-        int found = 0;
-        for (Entry<String, String> entry : encryptionContext.entrySet()) {
-            if ("param".equals(entry.getKey())) {
-                assertEquals("L’homme c’est rien", entry.getValue());
-                found++;
-            } else if ("test".equals(entry.getKey())) {
-                assertEquals("l’oeuvre c’est tout", entry.getValue());
-                found++;
-            } else if ("valueless".equals(entry.getKey())) {
-                assertEquals("An empty value must still be added!", "", entry.getValue());
-                found++;
-            }
-        }
-        assertEquals("Test did not find right number of key and value pairs", NUMBER_OF_ENTRIES, found);
+        assertThat(KmsTextEncryptor.extractEncryptionContext(ENCRYPTION_TEXT))
+                .containsOnly(
+                    entry("param", "L’homme c’est rien"),
+                    entry("test", "l’oeuvre c’est tout"),
+                    entry("valueless", ""));
     }
 
     @Test

--- a/src/test/java/de/zalando/spring/cloud/config/aws/kms/KmsEncryptionContextTest.java
+++ b/src/test/java/de/zalando/spring/cloud/config/aws/kms/KmsEncryptionContextTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2015 Zalando SE (https://tech.zalando.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.zalando.spring.cloud.config.aws.kms;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.junit.Test;
+
+/**
+ * Tests for encryption context methods in {@link KmsTextEncryptor}.
+ */
+public class KmsEncryptionContextTest {
+
+    private static final String ENCRYPTION_TEXT = "(param=TOKAmWhvbW1lIGPigJllc3Qgcmllbg==,"
+            + "test=bOKAmW9ldXZyZSBj4oCZZXN0IHRvdXQ=,valueless)remaining";
+
+    @Test
+    public void testExtractEncryptionContext() {
+        Map<String, String> encryptionContext = KmsTextEncryptor.extractEncryptionContext(ENCRYPTION_TEXT);
+        assertEquals(3, encryptionContext.size());
+        for (Entry<String, String> entry : encryptionContext.entrySet()) {
+            if ("param".equals(entry.getKey())) {
+                assertEquals("L’homme c’est rien", entry.getValue());
+            } else if ("test".equals(entry.getKey())) {
+                assertEquals("l’oeuvre c’est tout", entry.getValue());
+            } else if ("valueless".equals(entry.getKey())) {
+                assertEquals("", entry.getValue());
+            }
+        }
+    }
+
+    @Test
+    public void testExtractEncryptionValue() {
+        String encryptionValue = KmsTextEncryptor.extractEncryptedValue(ENCRYPTION_TEXT);
+        assertEquals("remaining", encryptionValue);
+    }
+
+}


### PR DESCRIPTION
This pull request adds support to encryption contexts with KMS. See issue #9 for more.

Encryption contexts are extra map of key=value passed during the encryption process. The same map values (order is not important) must be provided for decryption.

This implementation has a custom syntax, where before the Base64 encoded encrypted text, we may have a map as follows:

```
(param1=abc,param2=xyz, test=123,emptyvalue)
```

Empty values are allowed for convenience. Values are Base64 encoded, and trimmed before decoding.

This does not need to be merged right now :-) I would prefer if others could review the code, and maybe if some other users could chime in and say whether they would use it, and how. The production systems I'm helping to maintain at the moment are not using encryption contexts (yet), but we have adopted KMS less than 6 months ago.

Will update this pull request with a commit to trim the values, which I forgot, and with a comment later to confirm if - besides what the unit tests are confirming - it works on AWS KMS too.

Thanks!
Bruno