### PR TITLE
The spring-cloud-config-client is not really neccessary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-config-client</artifactId>
+            <artifactId>spring-cloud-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>


### PR DESCRIPTION
Having `spring-cloud-config-client` on the classpath make spring applications to try to connect to a config server during bootstrap.
We use this library to decrypt values during bootstrap, but we don't need to connect to a spring config server.
Replacing the `spring-cloud-config-client` dependency with `spring-cloud-context` seems sufficient to make the library work, saving application errors during bootstrap trying to connect to a config server.
The `spring-boot-autoconfigure` dependency is needed for the bean annotations on the `KmsEncryptionConfiguration` class.

The tests are passing, but I'd like your feedback about this change.