### PR TITLE
Issue #36 - Adding VPC Endpoint Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,5 +117,6 @@ hs_err_pid*
 # Eclipse
 .classpath
 .project
+.factorypath
 
 

--- a/README.md
+++ b/README.md
@@ -42,12 +42,30 @@ E.g. `bootstrap.yml`:
             
             # Optional: Turn off the KMS feature completely (e.g. for local development) 
             enabled: false
+            
+            # Optional: Enable endpoint usage, if provided, aws.kms.region should be excluded as it will be ignored
+            endpoint:
+                # Required: service endpoint (vpc endpoint or standard regional endpoint); https://kms.eu-central-1.amazonaws.com is also valid
+                service-endpoint: kms.eu-central-1.amazonaws.com
+                
+                # Optional: signing region for SigV4 signing of requests - if used, should be different from the already regional service-endpoint
+                signing-region: us-east-1
+                
+                
 
 The *aws.kms.keyId* property is required only if you intend to encrypt values in your application. The following contains the properties used by this library.
 
 - aws.kms.keyId
     - either the keyId or the full ARN of the KMS key
 - aws.kms.enabled (defaults to true)
+- aws.kms.endpoint
+    - if used, this will cause aws.kms.region to be ignored
+- aws.kms.endpoint.service-endpoint
+    - endpoint address with or without https:// prefix
+- aws.kms.endpoint.signing-region 
+    - in most cases can be omitted
+    - if provided, it will usually differ from region that hosts the service-endpoint
+ 
 
 **AWS region** and **credentials** are taken from the environment through the
 [Default Credential Provider Chain](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default)

--- a/src/main/java/de/zalando/spring/cloud/config/aws/kms/KmsEncryptionConfiguration.java
+++ b/src/main/java/de/zalando/spring/cloud/config/aws/kms/KmsEncryptionConfiguration.java
@@ -56,44 +56,29 @@ class KmsEncryptionConfiguration {
     }
     
     @Configuration
-    @ConditionalOnProperty(name="aws.kms.endpoint.service-endpoint")
     @ConditionalOnMissingBean(AWSKMS.class)
-    static class KmsConfigurationEndpoint {
+    static class KmsConfiguration {
 
         private final KmsProperties properties;
 
         @Autowired
-        public KmsConfigurationEndpoint(KmsProperties properties) {
+        public KmsConfiguration(KmsProperties properties) {
             this.properties = properties;
         }
 
         @Bean
         public AWSKMS kms() {
             final AWSKMSClientBuilder builder = AWSKMSClient.builder();
-           	builder.withEndpointConfiguration(new EndpointConfiguration(properties.getEndpoint().getServiceEndpoint(), properties.getEndpoint().getSigningRegion()));
+            
+            if (Optional.ofNullable(properties.getEndpoint()).isPresent()) {
+               	builder.withEndpointConfiguration(new EndpointConfiguration(properties.getEndpoint().getServiceEndpoint(), properties.getEndpoint().getSigningRegion()));
+            } else {
+                Optional.ofNullable(properties.getRegion()).ifPresent(builder::setRegion);
+            }
+            
             return builder.build();
         }
 
     }
 
-    @Configuration
-    @ConditionalOnProperty(name="aws.kms.region", matchIfMissing=true)
-    @ConditionalOnMissingBean(AWSKMS.class)
-    static class KmsConfigurationRegion {
-
-        private final KmsProperties properties;
-
-        @Autowired
-        public KmsConfigurationRegion(KmsProperties properties) {
-            this.properties = properties;
-        }
-
-        @Bean
-        public AWSKMS kms() {
-            final AWSKMSClientBuilder builder = AWSKMSClient.builder();
-            Optional.ofNullable(properties.getRegion()).ifPresent(builder::setRegion);
-            return builder.build();
-        }
-
-    }
 }

--- a/src/main/java/de/zalando/spring/cloud/config/aws/kms/KmsProperties.java
+++ b/src/main/java/de/zalando/spring/cloud/config/aws/kms/KmsProperties.java
@@ -23,6 +23,46 @@ public class KmsProperties {
      */
     private String region;
 
+    /**
+     * <strong>Optional</strong> service endpoint and signing region of AWS KMS that you would like to route to.
+     * If provided, must supply either a custom created VPC Endpoint or one of the KMS Endpoints listed <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#kms_region">here</a>.
+     * In the event that both region and endpoint properties are both supplied, region will be ignored as region is derived from the service endpoint.
+     */
+    private Endpoint endpoint;
+    
+    @ConfigurationProperties("endpoint")
+    public static class Endpoint {
+
+        /**
+         * <strong>Required<strong> service endpoint, either with or without the protocol (e.g. https://sns.us-west-1.amazonaws.com or sns.us-west-1.amazonaws.com)
+         */
+    	private String serviceEndpoint;
+
+    	/**
+    	 * <strong>Optional</strong> signing region. The region to use for SigV4 signing of requests (e.g. us-west-1)
+    	 * In most cases, this can be omitted.  There are use cases where a signing region is also 
+    	 * needed and it may be different from the region where the service endpoint lives.
+    	 */
+    	private String signingRegion;
+		
+    	public String getServiceEndpoint() {
+			return serviceEndpoint;
+		}
+
+		public void setServiceEndpoint(String serviceEndpoint) {
+			this.serviceEndpoint = serviceEndpoint;
+		}
+
+		public String getSigningRegion() {
+			return signingRegion;
+		}
+		
+    	public void setSigningRegion(String signingRegion) {
+			this.signingRegion = signingRegion;
+		}
+    	
+    }
+    
     public String getKeyId() {
         return keyId;
     }
@@ -38,4 +78,13 @@ public class KmsProperties {
     public void setRegion(String region) {
         this.region = region;
     }
+
+	public Endpoint getEndpoint() {
+		return endpoint;
+	}
+
+	public void setEndpoint(Endpoint endpoint) {
+		this.endpoint = endpoint;
+	}
+    
 }

--- a/src/main/java/de/zalando/spring/cloud/config/aws/kms/KmsProperties.java
+++ b/src/main/java/de/zalando/spring/cloud/config/aws/kms/KmsProperties.java
@@ -30,11 +30,10 @@ public class KmsProperties {
      */
     private Endpoint endpoint;
     
-    @ConfigurationProperties("endpoint")
     public static class Endpoint {
 
         /**
-         * <strong>Required<strong> service endpoint, either with or without the protocol (e.g. https://sns.us-west-1.amazonaws.com or sns.us-west-1.amazonaws.com)
+         * <strong>Required<strong> service endpoint, either with or without the protocol (e.g. https://kms.us-west-2.amazonaws.com or kms.us-west-2.amazonaws.com)
          */
     	private String serviceEndpoint;
 

--- a/src/test/java/de/zalando/spring/cloud/config/aws/kms/NoKmsEncryptionIntegrationConfigurationTest.java
+++ b/src/test/java/de/zalando/spring/cloud/config/aws/kms/NoKmsEncryptionIntegrationConfigurationTest.java
@@ -1,9 +1,12 @@
 package de.zalando.spring.cloud.config.aws.kms;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.net.URI;
 
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -20,11 +23,6 @@ import org.springframework.util.ReflectionUtils;
 
 import com.amazonaws.services.kms.AWSKMS;
 import com.amazonaws.services.kms.AWSKMSClient;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.lang.reflect.Field;
-import java.net.URI;
 
 /**
  * During this integration test, a real AWSKMSClient is created, but there are no encrypted properties, so te client is

--- a/src/test/resources/application-noEncryptionEndpoint.yml
+++ b/src/test/resources/application-noEncryptionEndpoint.yml
@@ -1,0 +1,2 @@
+# simply plaintext
+secret: 'secret'

--- a/src/test/resources/bootstrap-noEncryptionEndpoint.yml
+++ b/src/test/resources/bootstrap-noEncryptionEndpoint.yml
@@ -1,0 +1,11 @@
+aws:
+  kms:
+    useMock: false
+    keyId: 'sample-key'
+    region: eu-central-1  # ignored
+    endpoint:
+      service-endpoint: kms.us-east-1.amazonaws.com
+      signing-region: us-east-2
+spring:
+  main:
+    banner-mode: "off"


### PR DESCRIPTION
The direct use of specific VPC Endpoints or standard regional KMS
endpoints was not supported by starter as is.  New configuration
properties will allow service endpoint and an optional signing region to
be specified.