### PR TITLE
support per-cipher options during decryption

### DIFF
--- a/zalando-cloud-aws-kms/README.md
+++ b/zalando-cloud-aws-kms/README.md
@@ -9,7 +9,7 @@ This is a Spring Cloud AWS add-on that provides a KMS client and encryption via 
 * Supports AWS KMS [encryption context](#use-an-encryption-context)
 * Supports different [output modes](#available-options) for decrypted values
 * Supports [asymmetric keys](#asymmetric-keys)
-* Minimal dependencies 
+* Minimal dependencies
 
 ## Installation
 
@@ -23,8 +23,8 @@ Given you have a [Spring Boot](http://projects.spring.io/spring-boot/) applicati
 
 ```xml
 <properties>
-...
-<zalando-cloud-aws.version>3.1.1</zalando-cloud-aws.version>
+    ...
+    <zalando-cloud-aws.version>3.1.1</zalando-cloud-aws.version>
 </properties>
 ```
 
@@ -32,9 +32,9 @@ Given you have a [Spring Boot](http://projects.spring.io/spring-boot/) applicati
 
 ```xml
 <dependency>
-	<groupId>org.zalando.awspring.cloud</groupId>
-	<artifactId>zalando-cloud-aws-kms</artifactId>
-	<version>${zalando-cloud-aws.version}</version>
+    <groupId>org.zalando.awspring.cloud</groupId>
+    <artifactId>zalando-cloud-aws-kms</artifactId>
+    <version>${zalando-cloud-aws.version}</version>
 </dependency>
 ```
 
@@ -47,7 +47,7 @@ spring:
   cloud:
     decrypt-environment-post-processor:
       enabled: false # disable environment post processor for rsa keys
----  
+---
 spring:
   cloud:
     aws:
@@ -65,22 +65,22 @@ encrypt:
     # Required for encrypting values.
     # Required for decrypting values with some asymmetric algorithm. 
     key-id: 9d9fca31-54c5-4df5-ba4f-127dfb9a5031
-            
+
     # Optional: Switch to asymmetric algorithm.
     # See com.amazonaws.services.kms.model.EncryptionAlgorithmSpec for available values.
     encryption-algorithm: "RSAES_OAEP_SHA_256"
 ```
 
 The `spring.cloud.aws.kms.key-id` property must be set if
-  - values need to be decrypted with an asymmetric key
-  - values need to be encrypted (with any algorithm)
-  
+- values need to be decrypted with an asymmetric key
+- values need to be encrypted (with any algorithm)
+
 Those are the properties used by this library:
 
 - `encrypt.kms.enabled`: (defaults to true)
 - `encrypt.kms.key-id`: either the keyId or the full ARN of the KMS key
 - `encrypt.kms.encryption-algorithm`: the encryption algorithm to use
- 
+
 
 ## Usage
 
@@ -127,15 +127,15 @@ encrypt:
 
 #### Decryption
 
-If all cipher values of your application have been encrypted with the same KMS key and algorithm, you can configure 
+If all cipher values of your application have been encrypted with the same KMS key and algorithm, you can configure
 the `keyId` and `encryptionAlgorithm` globally in the `bootstrap.yml` as shown above. In case you have to decrypt
-ciphers from different keys or different algorithms, you can specify those separately for each key using the 
+ciphers from different keys or different algorithms, you can specify those separately for each key using the
 ["extra options"](#use-extra-options) approach, e.g., `application.yml`
 
 ```yaml
     secret1: "{cipher}SSdtIHNvbWUgYXN5bW1ldHJpY2FsbHkgZW5jcnlwdGVkIHNlY3JldA=="
-    secret2: "{cipher}[algorithm=SYMMETRIC_DEFAULT]U3ltbWV0cmljIGFuZCBhc3ltbWV0cmljIHNlY3JldHMgY2FuIGJlIG1peGVk"
-    secret3: "{cipher}[algorithm=RSAES_OAEP_SHA_256,keyId=9d9fca31-54c5-4df5-ba4f-127dfb9a5031]SSBoYXZlIGEgY3VzdG9tIGtleSBhbmQgYWxnb3JpdGht"
+    secret2: "{cipher}[encryptionAlgorithm=SYMMETRIC_DEFAULT]U3ltbWV0cmljIGFuZCBhc3ltbWV0cmljIHNlY3JldHMgY2FuIGJlIG1peGVk"
+    secret3: "{cipher}[encryptionAlgorithm=RSAES_OAEP_SHA_256,keyId=9d9fca31-54c5-4df5-ba4f-127dfb9a5031]SSBoYXZlIGEgY3VzdG9tIGtleSBhbmQgYWxnb3JpdGht"
 ```
 ### Use extra options
 
@@ -156,7 +156,7 @@ Encryption context and extra options can be combined in any order.
 | Option | Values | Default | Description |
 | ------ | ------ | ------- | ----------- |
 | output | `plain`, `base64` | `plain` | `plain` returns the decrypted secret as simple String. `base64` returns the decrypted secret in Base64 encoding. This is useful in cases where the plaintext secret contains non-printable characters (e.g. random AES keys) |
-| algorithm | as defined in `com.amazonaws.services.kms.model.EncryptionAlgorithmSpec` | `null` | Use the algorithm to decrypt the cipher text. |
+| encryptionAlgorithm | as defined in `software.amazon.awssdk.services.kms.model.EncryptionAlgorithmSpec` | `null` | Use the algorithm to decrypt the cipher text. |
 | keyId | ID or full ARN of a KMS key | `null` | Use the given key to decrypt the cipher text |
 
 

--- a/zalando-cloud-aws-kms/src/main/java/org/zalando/awsspring/cloud/bootstrap/encrypt/KmsTextEncryptor.java
+++ b/zalando-cloud-aws-kms/src/main/java/org/zalando/awsspring/cloud/bootstrap/encrypt/KmsTextEncryptor.java
@@ -1,6 +1,7 @@
 package org.zalando.awsspring.cloud.bootstrap.encrypt;
 
 import java.util.Base64;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,10 +15,10 @@ import software.amazon.awssdk.services.kms.model.EncryptRequest;
 import software.amazon.awssdk.services.kms.model.EncryptResponse;
 
 /**
- * Implementation of TextEncryptor that uses AWS KMS. 
+ * Implementation of TextEncryptor that uses AWS KMS.
  */
 public class KmsTextEncryptor implements TextEncryptor {
-	
+
 	private static Logger LOG = LoggerFactory.getLogger(KmsTextEncryptor.class);
 
 	private final KmsClient kmsClient;
@@ -40,55 +41,60 @@ public class KmsTextEncryptor implements TextEncryptor {
 		}
 	}
 
-	
+
 	@Override
 	public String encrypt(String text) {
 		EncryptRequest request = buildEncryptRequest(text);
 		EncryptResponse response = kmsClient.encrypt(request);
-		
+
 		byte[] cipherBytes = response.ciphertextBlob().asByteArray();
-		
+
 		return convertToString(cipherBytes, OutputMode.BASE64);
 	}
 
 	private EncryptRequest buildEncryptRequest(String text) {
 		EncryptRequest.Builder requestBuilder = EncryptRequest.builder().keyId(kmsKeyId)
-				.plaintext(SdkBytes.fromUtf8String(text));
-		
+			.plaintext(SdkBytes.fromUtf8String(text));
+
 		if (kmsEncryptionAlgorithm != null) {
 			requestBuilder = requestBuilder.encryptionAlgorithm(kmsEncryptionAlgorithm);
 		}
-		
+
 		return requestBuilder.build();
 	}
-	
-	
+
+
 	@Override
 	public String decrypt(String encryptedText) {
-		
+
 		EncryptedToken encryptedToken = EncryptedToken.parse(encryptedText);
 		LOG.info("decrypting {} as part of stack.\n{}", encryptedText, Thread.currentThread().getStackTrace());
-		
-		DecryptRequest request = buildDecryptRequest(encryptedToken.getCipher());
-		
+
+		DecryptRequest request = buildDecryptRequest(encryptedToken);
+
 		DecryptResponse response = kmsClient.decrypt(request);
 		byte[] textBytes = response.plaintext().asByteArray();
-		
+
 		return convertToString(textBytes, OutputMode.PLAIN);
 	}
-	
-	private DecryptRequest buildDecryptRequest(byte[] encryptedText) {
+
+	private DecryptRequest buildDecryptRequest(EncryptedToken encryptedToken) {
+		EncryptedTokenOptions options = encryptedToken.getOptions();
+		final String keyId = Optional.ofNullable(options)
+			.map(EncryptedTokenOptions::getKeyId)
+			.orElse(kmsKeyId);
+		final String algorithm = Optional.ofNullable(options)
+			.map(EncryptedTokenOptions::getEncryptionAlgorithm)
+			.orElse(kmsEncryptionAlgorithm);
+
 		DecryptRequest.Builder requestBuilder = DecryptRequest.builder();
-		
-		requestBuilder = requestBuilder.ciphertextBlob(SdkBytes.fromByteArray(encryptedText));
-		if (kmsKeyId != null) {
-			requestBuilder = requestBuilder.keyId(kmsKeyId);
-		}
-		if (kmsEncryptionAlgorithm != null) {
-			requestBuilder = requestBuilder.encryptionAlgorithm(kmsEncryptionAlgorithm);
-		}
-		
+
+		requestBuilder = requestBuilder
+			.ciphertextBlob(SdkBytes.fromByteArray(encryptedToken.getCipher()))
+			.keyId(keyId)
+			.encryptionAlgorithm(algorithm);
+
 		return requestBuilder.build();
-		
+
 	}
 }

--- a/zalando-cloud-aws-kms/src/main/java/org/zalando/awsspring/cloud/bootstrap/encrypt/KmsTextEncryptor.java
+++ b/zalando-cloud-aws-kms/src/main/java/org/zalando/awsspring/cloud/bootstrap/encrypt/KmsTextEncryptor.java
@@ -87,14 +87,11 @@ public class KmsTextEncryptor implements TextEncryptor {
 			.map(EncryptedTokenOptions::getEncryptionAlgorithm)
 			.orElse(kmsEncryptionAlgorithm);
 
-		DecryptRequest.Builder requestBuilder = DecryptRequest.builder();
-
-		requestBuilder = requestBuilder
+		return DecryptRequest.builder()
 			.ciphertextBlob(SdkBytes.fromByteArray(encryptedToken.getCipher()))
 			.keyId(keyId)
-			.encryptionAlgorithm(algorithm);
-
-		return requestBuilder.build();
-
+			.encryptionAlgorithm(algorithm)
+			.encryptionContext(encryptedToken.getContext())
+			.build();
 	}
 }

--- a/zalando-cloud-aws-kms/src/test/java/org/zalando/awsspring/cloud/bootstrap/encrypt/KmsTextEncryptorTest.java
+++ b/zalando-cloud-aws-kms/src/test/java/org/zalando/awsspring/cloud/bootstrap/encrypt/KmsTextEncryptorTest.java
@@ -1,100 +1,126 @@
 package org.zalando.awsspring.cloud.bootstrap.encrypt;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer.Service;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
-import org.zalando.awsspring.cloud.bootstrap.encrypt.KmsTextEncryptor;
-
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.kms.KmsClient;
-import software.amazon.awssdk.services.kms.model.CreateKeyRequest;
-import software.amazon.awssdk.services.kms.model.CreateKeyResponse;
-import software.amazon.awssdk.services.kms.model.EncryptRequest;
-import software.amazon.awssdk.services.kms.model.EncryptResponse;
-import software.amazon.awssdk.services.kms.model.KeySpec;
-import software.amazon.awssdk.services.kms.model.KeyUsageType;
+import software.amazon.awssdk.services.kms.model.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.mockito.Mockito.*;
 
 @Testcontainers
 public class KmsTextEncryptorTest {
 
-	@Container
-	private static final LocalStackContainer localstack = new LocalStackContainer(
-			DockerImageName.parse("localstack/localstack:latest")).withServices(Service.KMS);
+    @Container
+    private static final LocalStackContainer localstack = new LocalStackContainer(
+        DockerImageName.parse("localstack/localstack:latest")).withServices(Service.KMS);
 
-	private static KmsClient kmsClient;
+    private static KmsClient kmsClient;
 
-	private static String symmetricKeyId;
+    private static String symmetricKeyId;
 
-	private static String rsaKeyId;
+    private static String rsaKeyId;
 
-	@BeforeAll
-	public static void beforeAll() {
-		kmsClient = KmsClient.builder().endpointOverride(localstack.getEndpoint())
-				.credentialsProvider(StaticCredentialsProvider
-						.create(AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey())))
-				.region(Region.of(localstack.getRegion())).build();
+    @BeforeAll
+    public static void beforeAll() {
+        kmsClient = KmsClient.builder().endpointOverride(localstack.getEndpoint())
+            .credentialsProvider(StaticCredentialsProvider
+                .create(AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey())))
+            .region(Region.of(localstack.getRegion())).build();
 
-		CreateKeyResponse response = kmsClient.createKey(CreateKeyRequest.builder().keySpec(KeySpec.SYMMETRIC_DEFAULT)
-				.keyUsage(KeyUsageType.ENCRYPT_DECRYPT).build());
-		symmetricKeyId = response.keyMetadata().keyId();
+        CreateKeyResponse response = kmsClient.createKey(CreateKeyRequest.builder().keySpec(KeySpec.SYMMETRIC_DEFAULT)
+            .keyUsage(KeyUsageType.ENCRYPT_DECRYPT).build());
+        symmetricKeyId = response.keyMetadata().keyId();
 
-		response = kmsClient.createKey(
-				CreateKeyRequest.builder().keySpec(KeySpec.RSA_4096).keyUsage(KeyUsageType.ENCRYPT_DECRYPT).build());
-		rsaKeyId = response.keyMetadata().keyId();
-	}
+        response = kmsClient.createKey(
+            CreateKeyRequest.builder().keySpec(KeySpec.RSA_4096).keyUsage(KeyUsageType.ENCRYPT_DECRYPT).build());
+        rsaKeyId = response.keyMetadata().keyId();
+    }
 
-	@Test
-	public void encryptSymmetric() throws Exception {
-		KmsTextEncryptor encryptor = new KmsTextEncryptor(kmsClient, symmetricKeyId, null);
-		String encrypted = encryptor.encrypt("secret");
+    @Test
+    public void encryptSymmetric() throws Exception {
+        KmsTextEncryptor encryptor = new KmsTextEncryptor(kmsClient, symmetricKeyId, null);
+        String encrypted = encryptor.encrypt("secret");
 
-		Assertions.assertThat(encrypted).isNotBlank().isBase64();
-	}
+        Assertions.assertThat(encrypted).isNotBlank().isBase64();
+    }
 
-	@Test
-	public void encryptRsa() throws Exception {
-		KmsTextEncryptor encryptor = new KmsTextEncryptor(kmsClient, rsaKeyId, null);
-		String encrypted = encryptor.encrypt("secret");
+    @Test
+    public void encryptRsa() throws Exception {
+        KmsTextEncryptor encryptor = new KmsTextEncryptor(kmsClient, rsaKeyId, null);
+        String encrypted = encryptor.encrypt("secret");
 
-		Assertions.assertThat(encrypted).isNotBlank().isBase64();
-	}
+        Assertions.assertThat(encrypted).isNotBlank().isBase64();
+    }
 
-	@Test
-	public void decryptSymmetric() throws Exception {
-		String password = "secret";
+    @Test
+    public void decryptSymmetric() throws Exception {
+        String password = "secret";
 
-		EncryptResponse response = kmsClient.encrypt(EncryptRequest.builder().keyId(symmetricKeyId)
-				.plaintext(SdkBytes.fromString(password, StandardCharsets.ISO_8859_1)).build());
-		String encrypted = Base64.getEncoder().encodeToString(response.ciphertextBlob().asByteArray());
+        EncryptResponse response = kmsClient.encrypt(EncryptRequest.builder().keyId(symmetricKeyId)
+            .plaintext(SdkBytes.fromString(password, StandardCharsets.ISO_8859_1)).build());
+        String encrypted = Base64.getEncoder().encodeToString(response.ciphertextBlob().asByteArray());
 
-		KmsTextEncryptor encryptor = new KmsTextEncryptor(kmsClient, symmetricKeyId, null);
-		String plaintext = encryptor.decrypt(encrypted);
+        KmsTextEncryptor encryptor = new KmsTextEncryptor(kmsClient, symmetricKeyId, null);
+        String plaintext = encryptor.decrypt(encrypted);
 
+        Assertions.assertThat(plaintext).isEqualTo(password);
+    }
+
+    @Test
+    public void decryptRsa() throws Exception {
+        String password = "secret";
+
+        EncryptResponse response = kmsClient.encrypt(EncryptRequest.builder().keyId(rsaKeyId)
+            .encryptionAlgorithm(EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256)
+            .plaintext(SdkBytes.fromString(password, StandardCharsets.ISO_8859_1)).build());
+        String encrypted = Base64.getEncoder().encodeToString(response.ciphertextBlob().asByteArray());
+
+        KmsTextEncryptor encryptor = new KmsTextEncryptor(kmsClient, rsaKeyId, null);
+        String plaintext = encryptor.decrypt(encrypted);
+
+        Assertions.assertThat(plaintext).isEqualTo(password);
+    }
+
+    @Test
+    public void decryptRsaByExtraOptions() throws Exception {
+        String password = "secret";
+		EncryptionAlgorithmSpec encryptionAlgorithm = EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256;
+
+        EncryptResponse response = kmsClient.encrypt(EncryptRequest.builder().keyId(rsaKeyId)
+            .encryptionAlgorithm(encryptionAlgorithm)
+            .plaintext(SdkBytes.fromString(password, StandardCharsets.ISO_8859_1)).build());
+        String encrypted = Base64.getEncoder().encodeToString(response.ciphertextBlob().asByteArray());
+
+        String encryptedOptions = String.format("[encryptionAlgorithm=%s,keyId=%s]%s", encryptionAlgorithm, rsaKeyId, encrypted);
+		KmsClient spyKmsClient = spy(kmsClient);
+        AtomicReference<DecryptResponse> responseCaptor = new AtomicReference<>();
+
+        doAnswer(invocation -> {
+            DecryptResponse decryptResponse = (DecryptResponse) invocation.callRealMethod();
+            responseCaptor.set(decryptResponse);
+            return decryptResponse;
+        }).when(spyKmsClient).decrypt(any(DecryptRequest.class));
+
+		KmsTextEncryptor encryptor = new KmsTextEncryptor(spyKmsClient, null, null);
+		String plaintext = encryptor.decrypt(encryptedOptions);
+
+		Assertions.assertThat(responseCaptor.get().keyId()).endsWith(rsaKeyId);
+		Assertions.assertThat(responseCaptor.get().encryptionAlgorithm()).isEqualTo(encryptionAlgorithm);
 		Assertions.assertThat(plaintext).isEqualTo(password);
-	}
-
-	@Test
-	public void decryptRsa() throws Exception {
-		String password = "secret";
-
-		EncryptResponse response = kmsClient.encrypt(EncryptRequest.builder().keyId(rsaKeyId)
-				.plaintext(SdkBytes.fromString(password, StandardCharsets.ISO_8859_1)).build());
-		String encrypted = Base64.getEncoder().encodeToString(response.ciphertextBlob().asByteArray());
-
-		KmsTextEncryptor encryptor = new KmsTextEncryptor(kmsClient, rsaKeyId, null);
-		String plaintext = encryptor.decrypt(encrypted);
-
-		Assertions.assertThat(plaintext).isEqualTo(password);
-	}
+    }
 }

--- a/zalando-cloud-aws-kms/src/test/java/org/zalando/awsspring/cloud/bootstrap/encrypt/KmsTextEncryptorTest.java
+++ b/zalando-cloud-aws-kms/src/test/java/org/zalando/awsspring/cloud/bootstrap/encrypt/KmsTextEncryptorTest.java
@@ -86,7 +86,6 @@ public class KmsTextEncryptorTest {
         String password = "secret";
 
         EncryptResponse response = kmsClient.encrypt(EncryptRequest.builder().keyId(rsaKeyId)
-            .encryptionAlgorithm(EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256)
             .plaintext(SdkBytes.fromString(password, StandardCharsets.ISO_8859_1)).build());
         String encrypted = Base64.getEncoder().encodeToString(response.ciphertextBlob().asByteArray());
 


### PR DESCRIPTION
The cipher-specific extra_options settings are not being applied at all. When configuring individual ciphers with custom options, these settings are being completely ignored in the current implementation.
