### PR TITLE
Release v4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	
 	<groupId>org.zalando.awspring.cloud</groupId>
 	<artifactId>zalando-cloud-aws</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.0.0</version>
 	<packaging>pom</packaging>
 	
 	<name>Zalando Cloud AWS</name>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	
 	<groupId>org.zalando.awspring.cloud</groupId>
 	<artifactId>zalando-cloud-aws</artifactId>
-	<version>4.0.0</version>
+	<version>4.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	
 	<name>Zalando Cloud AWS</name>

--- a/zalando-cloud-aws-autoconfigure/pom.xml
+++ b/zalando-cloud-aws-autoconfigure/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.zalando.awspring.cloud</groupId>
 		<artifactId>zalando-cloud-aws</artifactId>
-		<version>4.0.0</version>
+		<version>4.0.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/zalando-cloud-aws-autoconfigure/pom.xml
+++ b/zalando-cloud-aws-autoconfigure/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.zalando.awspring.cloud</groupId>
 		<artifactId>zalando-cloud-aws</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.0.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/zalando-cloud-aws-kms/pom.xml
+++ b/zalando-cloud-aws-kms/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.zalando.awspring.cloud</groupId>
 		<artifactId>zalando-cloud-aws</artifactId>
-		<version>4.0.0</version>
+		<version>4.0.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/zalando-cloud-aws-kms/pom.xml
+++ b/zalando-cloud-aws-kms/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.zalando.awspring.cloud</groupId>
 		<artifactId>zalando-cloud-aws</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.0.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/zalando-cloud-aws-samples/zalando-cloud-aws-kms-sample/pom.xml
+++ b/zalando-cloud-aws-samples/zalando-cloud-aws-kms-sample/pom.xml
@@ -12,13 +12,13 @@
 	
 	<groupId>org.zalando.awspring.cloud</groupId>
 	<artifactId>zalando-cloud-aws-kms-sample</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.0.0</version>
 	<packaging>jar</packaging>
 	<name>Zalando Cloud AWS KMS Sample</name>
 	
 	<properties>
 		<java.version>17</java.version>
-		<spring-cloud.version>2025.0.1</spring-cloud.version>
+		<spring-cloud.version>2025.1.0</spring-cloud.version>
 		<awsspring.version>4.0.0</awsspring.version>
 	</properties>
 	

--- a/zalando-cloud-aws-samples/zalando-cloud-aws-kms-sample/pom.xml
+++ b/zalando-cloud-aws-samples/zalando-cloud-aws-kms-sample/pom.xml
@@ -12,7 +12,7 @@
 	
 	<groupId>org.zalando.awspring.cloud</groupId>
 	<artifactId>zalando-cloud-aws-kms-sample</artifactId>
-	<version>4.0.0</version>
+	<version>4.0.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>Zalando Cloud AWS KMS Sample</name>
 	

--- a/zalando-cloud-aws-starters/zalando-cloud-aws-starter-kms/pom.xml
+++ b/zalando-cloud-aws-starters/zalando-cloud-aws-starter-kms/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>zalando-cloud-aws</artifactId>
 		<groupId>org.zalando.awspring.cloud</groupId>
-		<version>4.0.0</version>
+		<version>4.0.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/zalando-cloud-aws-starters/zalando-cloud-aws-starter-kms/pom.xml
+++ b/zalando-cloud-aws-starters/zalando-cloud-aws-starter-kms/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>zalando-cloud-aws</artifactId>
 		<groupId>org.zalando.awspring.cloud</groupId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.0.0</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION
This pull request updates the project version from a snapshot to the official `4.0.0` release across all modules and bumps the Spring Cloud dependency in the KMS sample. These changes prepare the codebase for a stable release.

Version updates for release:

* Updated the `version` field from `4.0.0-SNAPSHOT` to `4.0.0` in the parent `pom.xml`, as well as in all child modules (`zalando-cloud-aws-autoconfigure`, `zalando-cloud-aws-kms`, `zalando-cloud-aws-starter-kms`, and the KMS sample), to mark the official release version. 

Dependency updates:

* Updated the `spring-cloud.version` property in `zalando-cloud-aws-kms-sample/pom.xml` from `2025.0.1` to `2025.1.0` for the latest Spring Cloud compatibility.