### PR TITLE
Release/4.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Releases
 ### Release to Sonatype Central
 
 * Create a release branch.
-* Adjust versions using versions-plugin. Make sure to also adjust the sample version. Commit and push this change.
+* Adjust versions using versions-plugin `mvn versions:set -DnewVersion=2.0.0 -DprocessAllModules=true`. Commit and push this change.
 * Adjust the compatibilty matrix in this file if its a major version upgrade.
 * Tag the current commit with the supposed release version and push the tag.
 * Adjust version using versions-plugin to new develeopment version.

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	
 	<groupId>org.zalando.awspring.cloud</groupId>
 	<artifactId>zalando-cloud-aws</artifactId>
-	<version>4.0.1</version>
+	<version>4.0.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	
 	<name>Zalando Cloud AWS</name>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,9 @@
 							<publishingServerId>central</publishingServerId>
 							<deploymentName>${project.name}:${project.version}</deploymentName>
 							<autoPublish>false</autoPublish>
+							<excludeArtifacts>
+								<artifactId>zalando-cloud-aws-kms-sample</artifactId>
+							</excludeArtifacts>
 						</configuration>
 					</plugin>
 				</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	
 	<groupId>org.zalando.awspring.cloud</groupId>
 	<artifactId>zalando-cloud-aws</artifactId>
-	<version>4.0.1-SNAPSHOT</version>
+	<version>4.0.1</version>
 	<packaging>pom</packaging>
 	
 	<name>Zalando Cloud AWS</name>

--- a/zalando-cloud-aws-autoconfigure/pom.xml
+++ b/zalando-cloud-aws-autoconfigure/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.zalando.awspring.cloud</groupId>
 		<artifactId>zalando-cloud-aws</artifactId>
-		<version>4.0.1</version>
+		<version>4.0.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/zalando-cloud-aws-autoconfigure/pom.xml
+++ b/zalando-cloud-aws-autoconfigure/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.zalando.awspring.cloud</groupId>
 		<artifactId>zalando-cloud-aws</artifactId>
-		<version>4.0.1-SNAPSHOT</version>
+		<version>4.0.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/zalando-cloud-aws-kms/pom.xml
+++ b/zalando-cloud-aws-kms/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.zalando.awspring.cloud</groupId>
 		<artifactId>zalando-cloud-aws</artifactId>
-		<version>4.0.1</version>
+		<version>4.0.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/zalando-cloud-aws-kms/pom.xml
+++ b/zalando-cloud-aws-kms/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.zalando.awspring.cloud</groupId>
 		<artifactId>zalando-cloud-aws</artifactId>
-		<version>4.0.1-SNAPSHOT</version>
+		<version>4.0.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/zalando-cloud-aws-samples/zalando-cloud-aws-kms-sample/pom.xml
+++ b/zalando-cloud-aws-samples/zalando-cloud-aws-kms-sample/pom.xml
@@ -12,7 +12,7 @@
 	
 	<groupId>org.zalando.awspring.cloud</groupId>
 	<artifactId>zalando-cloud-aws-kms-sample</artifactId>
-	<version>4.0.1</version>
+	<version>4.0.2-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>Zalando Cloud AWS KMS Sample</name>
 	

--- a/zalando-cloud-aws-samples/zalando-cloud-aws-kms-sample/pom.xml
+++ b/zalando-cloud-aws-samples/zalando-cloud-aws-kms-sample/pom.xml
@@ -12,7 +12,7 @@
 	
 	<groupId>org.zalando.awspring.cloud</groupId>
 	<artifactId>zalando-cloud-aws-kms-sample</artifactId>
-	<version>4.0.1-SNAPSHOT</version>
+	<version>4.0.1</version>
 	<packaging>jar</packaging>
 	<name>Zalando Cloud AWS KMS Sample</name>
 	

--- a/zalando-cloud-aws-starters/zalando-cloud-aws-starter-kms/pom.xml
+++ b/zalando-cloud-aws-starters/zalando-cloud-aws-starter-kms/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>zalando-cloud-aws</artifactId>
 		<groupId>org.zalando.awspring.cloud</groupId>
-		<version>4.0.1</version>
+		<version>4.0.2-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/zalando-cloud-aws-starters/zalando-cloud-aws-starter-kms/pom.xml
+++ b/zalando-cloud-aws-starters/zalando-cloud-aws-starter-kms/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>zalando-cloud-aws</artifactId>
 		<groupId>org.zalando.awspring.cloud</groupId>
-		<version>4.0.1-SNAPSHOT</version>
+		<version>4.0.1</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION
This pull request prepares the project for the `4.0.1` release by updating version numbers from `4.0.1-SNAPSHOT` to `4.0.1` across all modules, clarifies the release instructions in the `README.md`, and ensures that the sample module is excluded from publishing to the central repository.

**Release version updates:**

* Updated the version from `4.0.1-SNAPSHOT` to `4.0.1` in the parent `pom.xml` and all module `pom.xml` files, including `zalando-cloud-aws-autoconfigure`, `zalando-cloud-aws-kms`, `zalando-cloud-aws-starter-kms`, and the sample module. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L15-R15) [[2]](diffhunk://#diff-e733c0a700cd567507ebea1af4f5f61b65831fcf72e457e6326f9ff01926d27aL9-R9) [[3]](diffhunk://#diff-6489bcc5a16925686ca81d89f0150159467cdfe348c542a9ddfc9310f3245f1aL9-R9) [[4]](diffhunk://#diff-747313fa250ca7b38d1cb3de15fa73e8fae8a11fe46a4b9fc8aaefb0383b8ed1L8-R8) [[5]](diffhunk://#diff-8e3a9a5ce1cdd52c94ace4efa80fb583c50108b3205fbd3914da1713162c8c72L15-R15)

**Release process improvements:**

* Updated the release instructions in `README.md` to specify the exact `mvn versions:set` command for setting the new version.

**Publishing configuration:**

* Modified the parent `pom.xml` to exclude the `zalando-cloud-aws-kms-sample` artifact from being published to the central repository.